### PR TITLE
Move Snackbar countdown inside button

### DIFF
--- a/src/packages/core/src/snackbar/demo/demo.ts
+++ b/src/packages/core/src/snackbar/demo/demo.ts
@@ -11,7 +11,7 @@ export class ESnackbarDemo {
     constructor(private snackbarService: ESnackbarService) { }
 
     public onClick(): void {
-        this.snackbarService.open({ text: 'Action completed...', buttonText: 'Отменить' });
+        this.snackbarService.open({ text: 'Action completed.', buttonText: 'Cancel' });
     }
 
 }

--- a/src/packages/core/src/snackbar/snackbar.animation.ts
+++ b/src/packages/core/src/snackbar/snackbar.animation.ts
@@ -1,19 +1,19 @@
 import {AnimationTriggerMetadata, trigger, state, transition, style, animate} from '@angular/animations';
 
-const animationTiming: number = 100;
+const animationTiming: string = '200ms ease-out';
 
 export const SnackbarAnimation: {
-    readonly fadeSnackbar: AnimationTriggerMetadata;
+    readonly hideSnackbar: AnimationTriggerMetadata;
 } = {
-    fadeSnackbar: trigger('fade', [
-            state('fadeOut', style({ opacity: 0 })),
-            state('fadeIn', style({ opacity: 1 })),
-            transition('* => fadeIn', [
-                style({ transform: 'scale3d(.3, .3, .3)', opacity: 1 }),
-                animate(animationTiming)
-            ]),
-            transition('fadeIn => fadeOut', [
-                animate(animationTiming, style({ transform: 'scale3d(.3, .3, .3)', opacity: 0 }))
-            ])
+    hideSnackbar: trigger('fade', [
+        state('hidden', style({ bottom: '-64px' })),
+        state('visible', style({ bottom: '16px' })),
+        transition('* => visible', [
+            style({ bottom: '-64px' }),
+            animate(animationTiming)
+        ]),
+        transition('visible => hidden', [
+            animate(animationTiming, style({ bottom: '-64px' }))
         ])
+    ])
 };

--- a/src/packages/core/src/snackbar/snackbar.html
+++ b/src/packages/core/src/snackbar/snackbar.html
@@ -5,6 +5,6 @@
     [ngClass]="{
         '_e_snackbar': true
     }">
-    <div class="_e_snackbar__text">{{ config?.text }} <span class="_e_snackbar__timer">:{{ count }}</span></div>
-    <button eButton class="_e_snackbar__button" (click)="onClose()">{{ config?.buttonText }}</button>
+    <div class="_e_snackbar__text">{{ config?.text }}</div>
+    <button eButton class="_e_snackbar__button" (click)="onClose()">{{ config?.buttonText }} :{{ paddedCount }}</button>
 </div>

--- a/src/packages/core/src/snackbar/snackbar.ts
+++ b/src/packages/core/src/snackbar/snackbar.ts
@@ -5,11 +5,12 @@ import {SnackbarConfig} from './models';
 
 const interval: number = 1000;
 const defaultDuration: number = 10;
+const countPadding: number = 2;
 
 @Component({
     selector: 'e-snackbar',
     templateUrl: './snackbar.html',
-    animations: [SnackbarAnimation.fadeSnackbar],
+    animations: [SnackbarAnimation.hideSnackbar],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -24,7 +25,11 @@ export class ESnackbar implements OnInit, OnDestroy {
     /**
      * @internal
      */
-    public animationState: 'fadeIn' | 'fadeOut' = 'fadeOut';
+    public paddedCount: string;
+    /**
+     * @internal
+     */
+    public animationState: 'visible' | 'hidden' = 'hidden';
 
     private manuallyClosed: boolean = false;
     private subs: Subscription;
@@ -34,7 +39,8 @@ export class ESnackbar implements OnInit, OnDestroy {
     public ngOnInit(): void {
         if (this.config) {
             this.count = this.config.duration || defaultDuration;
-            this.animationState = 'fadeIn';
+            this.paddedCount = this.count.toString().padStart(countPadding, '0');
+            this.animationState = 'visible';
             this.initTimer();
         }
     }
@@ -49,7 +55,7 @@ export class ESnackbar implements OnInit, OnDestroy {
      * @internal
      */
     public onClose(): void {
-        this.animationState = 'fadeOut';
+        this.animationState = 'hidden';
         this.manuallyClosed = true;
     }
 
@@ -57,7 +63,7 @@ export class ESnackbar implements OnInit, OnDestroy {
      * @internal
      */
     public onAnimationEnd(): void {
-        if (this.animationState === 'fadeOut') {
+        if (this.animationState === 'hidden') {
             this.close.emit(this.manuallyClosed);
         }
     }
@@ -70,8 +76,9 @@ export class ESnackbar implements OnInit, OnDestroy {
         this.subs = timerSource.subscribe((): void => {
             if (this.count) {
                 this.count--;
+                this.paddedCount = this.count.toString().padStart(countPadding, '0');
             } else {
-                this.animationState = 'fadeOut';
+                this.animationState = 'hidden';
             }
             this.cdr.markForCheck();
         });


### PR DESCRIPTION
This moves `Snackbar` countdown inside "Cancel" button according to recommendations from cft-group/elephas#65

<img width="717" alt="image" src="https://user-images.githubusercontent.com/2337671/97547682-af66bc80-1a00-11eb-9214-1a034535667f.png">
