### PR TITLE
Add support for typescript versions <3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16551,6 +16551,25 @@
         "dotenv-defaults": "^1.0.2"
       }
     },
+    "downlevel-dts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.7.0.tgz",
+      "integrity": "sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.3",
+        "typescript": "^4.1.0-dev.20201026"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+          "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+          "dev": true
+        }
+      }
+    },
     "downshift": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/node": "^14.0.27",
     "babel-loader": "^8.1.0",
     "codelyzer": "^6.0.0",
+    "downlevel-dts": "^0.7.0",
     "husky": "^4.2.5",
     "jasmine-core": "^3.6.0",
     "jasmine-spec-reporter": "^5.0.2",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -18,6 +18,10 @@
   },
   "scripts": {
     "build": "export PACKAGE_NAME=`basename $INIT_CWD` && ng build --prod $PACKAGE_NAME",
-    "prepublishOnly": "npm run build"
+    "downlevelDts": "cd dist && npx downlevel-dts . ts3.4 [--to=3.4]",
+    "prepublishOnly": "npm run build && npm run downlevelDts"
+  },
+  "typesVersions": {
+    "<3.9": { "*": ["ts3.4/*"] }
   }
 }

--- a/src/packages/layout/package.json
+++ b/src/packages/layout/package.json
@@ -20,6 +20,10 @@
   },
   "scripts": {
     "build": "export PACKAGE_NAME=`basename $INIT_CWD` && ng build --prod $PACKAGE_NAME",
-    "prepublishOnly": "npm run build"
+    "downlevelDts": "cd dist && npx downlevel-dts . ts3.4 [--to=3.4]",
+    "prepublishOnly": "npm run build && npm run downlevelDts"
+  },
+  "typesVersions": {
+    "<3.9": { "*": ["ts3.4/*"] }
   }
 }


### PR DESCRIPTION
TypeScript 3.7 introduced a breaking change; hence developers using older versions of Angular can't use the library. See discussion here: https://github.com/microsoft/TypeScript/issues/33939

This PR adds support for older TS versions by providing alternative `.d.ts` files converted via `downlevel-dts`.